### PR TITLE
Removing additional fields to bitcoin.js

### DIFF
--- a/lib/history.js
+++ b/lib/history.js
@@ -61,7 +61,7 @@ export function compareByOldestAndType(
 }
 
 export function analyzeTransaction(
-    {id, tx, height, timestamp}: TransactionInfo,
+    {id, tx, height, timestamp, inputIds}: TransactionInfo,
     transactions: TransactionMap,
     external: Chain,
     internal: Chain
@@ -77,8 +77,8 @@ export function analyzeTransaction(
     let value = 0;
 
     // subtract debit impact value
-    tx.ins.forEach((i) => {
-        let o = transactions.getOutput(i.id, i.index);
+    tx.ins.forEach((i, index) => {
+        let o = transactions.getOutput(inputIds[index], i.index);
         if (o && isCredit(o)) {
             value -= o.value;
             nDebit++;

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -18,6 +18,9 @@ export class TransactionInfo {
     height: ?number;
     timestamp: ?number;
 
+    inputIds: Array<string>;
+    outputAddresses: Array<?string>;
+
     constructor(
         tx: Transaction,
         id: string,
@@ -28,18 +31,17 @@ export class TransactionInfo {
         this.id = id;
         this.height = height;
         this.timestamp = timestamp;
-    }
 
-    static fromJSON(data: TransactionInfoData) {
-        let tx = Transaction.fromHex(data.tx);
-
+        let inputIds = [];
         tx.ins.forEach((input) => {
             let hash = input.hash;
             Array.prototype.reverse.call(hash);
-            input.id = hash.toString('hex');
+            inputIds.push(hash.toString('hex'));
             Array.prototype.reverse.call(hash);
         });
+        this.inputIds = inputIds;
 
+        let outputAddresses = [];
         tx.outs.forEach((output) => {
             let address;
             try {
@@ -48,8 +50,13 @@ export class TransactionInfo {
                 console.warn('Error while parsing output script', e);
                 address = null;
             }
-            output.address = address;
+            outputAddresses.push(address);
         });
+        this.outputAddresses = outputAddresses;
+    }
+
+    static fromJSON(data: TransactionInfoData): TransactionInfo {
+        let tx = Transaction.fromHex(data.tx);
 
         return new TransactionInfo(
             tx,

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -32,16 +32,16 @@ export function collectUnspents(
 
     // keep track of spent outputs
     infos.forEach((info) => {
-        info.tx.ins.forEach((i) => {
-            let o = transactions.getOutput(i.id, i.index);
+        info.tx.ins.forEach((i, index) => {
+            let o = transactions.getOutput(info.inputIds[index], i.index);
             if (o) {
                 spent.add(o);
             }
         });
     });
 
-    let isCredit = (o) => {
-        let address = o.address;
+    let isCredit = (info, o, index) => {
+        let address = info.outputAddresses[index];
         return address &&
                (chainContainsAddress(internal, address) ||
                 chainContainsAddress(external, address));
@@ -58,7 +58,7 @@ export function collectUnspents(
         let coinbase = isCoinbase(info.tx);
 
         info.tx.outs.forEach((o, index) => {
-            if (spent.has(o) || !isCredit(o)) {
+            if (spent.has(o) || !isCredit(info, o, index)) {
                 return;
             }
             unspents.push({

--- a/type/bitcoinjs-lib.js
+++ b/type/bitcoinjs-lib.js
@@ -22,17 +22,11 @@ declare module 'bitcoinjs-lib' {
         hash: Buffer;
         index: number;
         sequence: number;
-
-        // additional: hash converted to tx id
-        id: string;
     };
 
     declare type Output = {
         script: Buffer;
         value: number;
-
-        // additional: cached address from the script
-        address: ?string;
     };
 
     declare var address: {


### PR DESCRIPTION
Adding non-standard fields to to third-party objects can cause confusion and decrease maintanability in long-term. (It's not clear when exactly are they present and when exactly aren't.)

I removed the fields from the declaration file and moved them to a separate fields in TransactionInfo. Now it's 100% sure that they will be present in TransactionInfo, since they are created in the constructor and not in fromJSON - before this change, the fields wouldn't be present when created from BitcoreBlockchain class. (Exactly the kind of error that type systems prevent :) )

I have _not_ tested if it works.
