### PR TITLE
Promise iterable

### DIFF
--- a/lib/.flowconfig
+++ b/lib/.flowconfig
@@ -10,3 +10,4 @@
 ../type
 
 [options]
+suppress_comment=\\(.\\|\n\\)*\\$FlowIssue

--- a/lib/.flowconfig
+++ b/lib/.flowconfig
@@ -4,6 +4,7 @@
 [include]
 ../node_modules/bitcoinjs-lib
 ../node_modules/socket.io-client
+../node_modules/whatwg-fetch
 
 [libs]
 ../type

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -2,6 +2,7 @@
 
 import { TransactionInfo, TransactionMap } from './transaction';
 import { Stream, Queue } from './stream';
+import { PromiseIterable } from './promise-iterable';
 
 import type { AddressSource, CachingSource, CachingSourceData } from './address';
 import type { TransactionMapData, TransactionInfoData } from './transaction';
@@ -405,13 +406,12 @@ export function isAccountEmpty(account: AccountDiscoveryState): boolean {
 export type AccountDiscoveryData = {
     sources: Array<CachingSourceData>;
     histories: Array<ChainHistory>;
-    transactionIds: Array<string>;
     blocks: BlockRange;
 };
 
 export type AccountDiscoveryDataWithTransactions = {
     data: AccountDiscoveryData;
-    getTransaction: (id: string) => Promise<TransactionInfoData>;
+    transactions: PromiseIterable<TransactionInfoData>;
 };
 
 export function storeAccountDiscovery(
@@ -424,21 +424,14 @@ export function storeAccountDiscovery(
     let data = {
         sources: sources.map((source) => source.store()),
         histories: account.map((state) => state.history),
-        transactionIds: txs.ids(),
         blocks: account[0].blocks,
     };
-    let getTransaction = (id: string) => {
-        let tx = txs.get(id);
-        if (tx == null) {
-            return Promise.reject(`Transaction ${id} cannot be found`);
-        }
-        return Promise.resolve(tx.toJSON());
-    };
-    return {data, getTransaction};
+    let transactions = PromiseIterable.fromIterable(txs.infos.values()).map(tx => tx.toJSON());
+    return {data, transactions};
 }
 
 export function restoreAccountDiscovery(
-    { data, getTransaction }: AccountDiscoveryDataWithTransactions,
+    { data, transactions }: AccountDiscoveryDataWithTransactions,
     sources: Array<CachingSource>
 ): Promise<AccountDiscoveryState> {
     data.sources.forEach((sdata, i) => {
@@ -446,18 +439,14 @@ export function restoreAccountDiscovery(
     });
     let chain = newChain();
     let blocks = data.blocks;
-    let transactions = new TransactionMap();
-    return promiseAllSequentially(data.transactionIds.map((id) => () => {
-        return getTransaction(id).then((item) => {
-            transactions.set(TransactionInfo.fromJSON(item))
-        });
-    })).then(() => {
+    let transactionsMap = new TransactionMap();
+    return transactions.map(tx => transactionsMap.set(TransactionInfo.fromJSON(tx))).resolveAll().then(() => {
         return data.histories.map((history) => {
             return {
                 history,
                 blocks,
                 chain,
-                transactions,
+                transactions: transactionsMap,
             };
         });
     });
@@ -494,12 +483,4 @@ export function discoverPortfolio(
         iterate(startIndex);
         return () => { disposed = true; };
     });
-}
-
-function promiseAllSequentially<X>(promiseFunctions: Array<() => Promise<X>>) {
-    return promiseFunctions.reduce((prev, fun) => {
-        return prev.then(() => {
-            fun();
-        });
-    }, Promise.resolve());
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,3 +10,4 @@ export * from './transaction';
 export * from './wallet';
 export * from './worker';
 export * from './serialize';
+export * from './promise-iterable';

--- a/lib/promise-iterable.js
+++ b/lib/promise-iterable.js
@@ -5,7 +5,7 @@
 export class PromiseIterable<T> {
     iterator: () => PromiseIterator<T>;
     constructor(iteratorFn: () => () => PromiseIteratorResult<T>) {
-        this.iterator = () => { return {next: iteratorFn()} };
+        this.iterator = () => { return {next: iteratorFn()}; };
     }
 
     static fromIterable(source: Iterable<T>): PromiseIterable<T> {
@@ -13,11 +13,11 @@ export class PromiseIterable<T> {
             /* $FlowIssue - missing API in flow*/
             let state: Iterator<T> = source[Symbol.iterator]();
             return () => {
-                let next = state.next(); 
+                let next = state.next();
                 let nvalue = next.value;
                 /* $FlowIssue
-                 * Cannot discriminate based on next.done, and I don't want to 
-                 * add (nvalue == null) ? new Value(nvalue) : null, 
+                 * Cannot discriminate based on next.done, and I don't want to
+                 * add (nvalue == null) ? new Value(nvalue) : null,
                  * since I want to allow T to be nullable
                  */
                 let value: ?Value<T> = next.done ? null : new Value(nvalue);
@@ -58,23 +58,22 @@ export class PromiseIterable<T> {
                     const res: Promise<?Value<T>> = state.then((next: T): ?Value<T> => {
                         isLast = !condition(next);
                         return new Value(next);
-                    })
+                    });
                     return res;
-                })
-            }
+                });
+            };
         });
     }
 
-    resolveAllWhile(condition: () => boolean): Promise {
+    reduce<U>(fn: (previous: U, value: T) => U, initial: U): Promise<U> {
         let iterator = this.iterator();
+        let state = initial;
         let next = () => {
-            if (!condition()) {
-                return Promise.resolve();
-            }
             return iterator.next().then(value => {
                 if (value == null) {
-                    return;
+                    return state;
                 } else {
+                    state = fn(state, value.value);
                     return next();
                 }
             });
@@ -82,8 +81,42 @@ export class PromiseIterable<T> {
         return next();
     }
 
+    reducePromise<U>(fn: (previous: U, value: T) => Promise<U>, initial: U): Promise<U> {
+        let iterator = this.iterator();
+        let state: Promise<U> = Promise.resolve(initial);
+        let next = (): Promise<U> => {
+            return iterator.next().then(value => {
+                if (value == null) {
+                    return state;
+                } else {
+                    const value_: Value<T> = value;
+                    return state.then((u: U) => {
+                        state = fn(u, value_.value);
+                        return next();
+                    });
+                }
+            });
+        };
+        return next();
+    }
+
     resolveAll(): Promise {
-        return this.resolveAllWhile(() => true);
+        return this.reduce((prev: void, value: T): void => { return; }, undefined);
+    }
+
+    resolveAllWhile(condition: () => boolean): Promise {
+        return this.reducePromise((prev: void, value: T): Promise<void> => {
+            if (!(condition())) {
+                return Promise.reject('CONDITION');
+            }
+            return Promise.resolve();
+        }, undefined).catch(err => {
+            if (err === 'CONDITION') {
+                return;
+            } else {
+                throw err;
+            }
+        });
     }
 
     map<U>(fn: (t: T) => U): PromiseIterable<U> {
@@ -152,7 +185,7 @@ export class PromiseIterable<T> {
                     return promise.then(iterable => {
                         state = iterable.iterator();
                         return state.next();
-                    })
+                    });
                 } else {
                     return state.next();
                 }
@@ -172,15 +205,15 @@ export class PromiseIterable<T> {
                 let fun = () => state.next().then((value) => {
                     if (value != null) {
                         arr.push(value.value);
-                        if (arr.length != size) {
-                            return fun()
+                        if (arr.length !== size) {
+                            return fun();
                         } else {
                             let res = new Value(arr);
                             arr = [];
                             return res;
                         }
                     } else {
-                        if (arr.length == 0) {
+                        if (arr.length === 0) {
                             return null;
                         } else {
                             last = true;
@@ -189,8 +222,39 @@ export class PromiseIterable<T> {
                     }
                 });
                 return fun();
-            }
+            };
         });
+    }
+
+    // When my promise rejects, resulting promise rejects with error
+    catchRejections(): PromiseIterable<T | Error> {
+        return new PromiseIterable(() => {
+            let state = this.iterator();
+            return () => {
+                return state.next().then(
+                    (value) => {
+                        return value == null ? null : new Value(value.value);
+                    },
+                    (error) => {
+                        const typedError = error instanceof Error ? error : new Error(error);
+                        return new Value(typedError);
+                    }
+                );
+            };
+        });
+    }
+
+    // Will not stop on rejections, but the resulting promise will be the first error
+    resolveAllCatchRejections(): Promise {
+        return this.catchRejections().reduce((prev, value) => {
+            if (prev instanceof Error) {
+                return prev;
+            }
+            if (value instanceof Error) {
+                return value;
+            }
+            return;
+        }, undefined);
     }
 }
 

--- a/lib/promise-iterable.js
+++ b/lib/promise-iterable.js
@@ -1,0 +1,207 @@
+/* @flow
+ * Typed delayed iterable
+ */
+
+export class PromiseIterable<T> {
+    iterator: () => PromiseIterator<T>;
+    constructor(iteratorFn: () => () => PromiseIteratorResult<T>) {
+        this.iterator = () => { return {next: iteratorFn()} };
+    }
+
+    static fromIterable(source: Iterable<T>): PromiseIterable<T> {
+        return new PromiseIterable(() => {
+            /* $FlowIssue - missing API in flow*/
+            let state: Iterator<T> = source[Symbol.iterator]();
+            return () => {
+                let next = state.next(); 
+                let nvalue = next.value;
+                /* $FlowIssue
+                 * Cannot discriminate based on next.done, and I don't want to 
+                 * add (nvalue == null) ? new Value(nvalue) : null, 
+                 * since I want to allow T to be nullable
+                 */
+                let value: ?Value<T> = next.done ? null : new Value(nvalue);
+                return Promise.resolve(value);
+            };
+        });
+    }
+
+    static fromRange(size: number): PromiseIterable<number> {
+        return new PromiseIterable(() => {
+            let state = -1;
+            return () => {
+                state++;
+                if (state < size) {
+                    return Promise.resolve(new Value(state));
+                } else {
+                    return Promise.resolve(null);
+                }
+            };
+        });
+    }
+
+
+    static fromGenerator(
+        initial: T,
+        generate: (state: T) => Promise<T>,
+        condition: (state: T) => boolean
+    ): PromiseIterable<T> {
+        return new PromiseIterable(() => {
+            let state: Promise<T> = Promise.resolve(initial);
+            let isLast = false;
+            return () => {
+                if (isLast) {
+                    return Promise.resolve(null);
+                }
+                return state.then((prev: T): Promise<?Value<T>> => {
+                    state = generate(prev);
+                    const res: Promise<?Value<T>> = state.then((next: T): ?Value<T> => {
+                        isLast = !condition(next);
+                        return new Value(next);
+                    })
+                    return res;
+                })
+            }
+        });
+    }
+
+    resolveAllWhile(condition: () => boolean): Promise {
+        let iterator = this.iterator();
+        let next = () => {
+            if (!condition()) {
+                return Promise.resolve();
+            }
+            return iterator.next().then(value => {
+                if (value == null) {
+                    return;
+                } else {
+                    return next();
+                }
+            });
+        };
+        return next();
+    }
+
+    resolveAll(): Promise {
+        return this.resolveAllWhile(() => true);
+    }
+
+    map<U>(fn: (t: T) => U): PromiseIterable<U> {
+        return new PromiseIterable(() => {
+            let state: PromiseIterator<T> = this.iterator();
+            return () => {
+                return state.next().then((value) => {
+                    if (value != null) {
+                        return new Value(fn(value.value));
+                    } else {
+                        return null;
+                    }
+                });
+            };
+        });
+    }
+
+    mapPromise<U>(fn: (t: T) => Promise<U>): PromiseIterable<U> {
+        return new PromiseIterable(() => {
+            let state: PromiseIterator<T> = this.iterator();
+            return () => {
+                return state.next().then((value) => {
+                    if (value != null) {
+                        return fn(value.value).then(r => new Value(r));
+                    } else {
+                        return null;
+                    }
+                });
+            };
+        });
+    }
+
+    static flatten(arrays: PromiseIterable<Array<T>>): PromiseIterable<T> {
+        return new PromiseIterable(() => {
+            let state: PromiseIterator<Array<T>> = arrays.iterator();
+            let lastArr: Array<T> = [];
+            return () => {
+                if (lastArr.length !== 0) {
+                    return Promise.resolve(new Value(lastArr.shift()));
+                }
+                let fun = () => state.next().then((array) => {
+                    if (array != null) {
+                        if (!(array.value instanceof Array)) {
+                            throw new Error('Cannot flatten non-array');
+                        }
+                        if (array.value.length === 0) {
+                            return fun();
+                        } else {
+                            lastArr.push(...array.value);
+                            return new Value(lastArr.shift());
+                        }
+                    } else {
+                        return null;
+                    }
+                });
+                return fun();
+            };
+        });
+    }
+
+    static fromPromise<T>(promise: Promise<PromiseIterable<T>>): PromiseIterable<T> {
+        return new PromiseIterable(() => {
+            let state: ?PromiseIterator<T> = null;
+            return () => {
+                if (state == null) {
+                    return promise.then(iterable => {
+                        state = iterable.iterator();
+                        return state.next();
+                    })
+                } else {
+                    return state.next();
+                }
+            };
+        });
+    }
+
+    chunk(size: number): PromiseIterable<Array<T>> {
+        return new PromiseIterable(() => {
+            let state: PromiseIterator<T> = this.iterator();
+            let last: boolean = false;
+            return () => {
+                let arr = [];
+                if (last) {
+                    return Promise.resolve(null);
+                }
+                let fun = () => state.next().then((value) => {
+                    if (value != null) {
+                        arr.push(value.value);
+                        if (arr.length != size) {
+                            return fun()
+                        } else {
+                            let res = new Value(arr);
+                            arr = [];
+                            return res;
+                        }
+                    } else {
+                        if (arr.length == 0) {
+                            return null;
+                        } else {
+                            last = true;
+                            return new Value(arr);
+                        }
+                    }
+                });
+                return fun();
+            }
+        });
+    }
+}
+
+class Value<T> {
+    value: T;
+    constructor(value: T) {
+        this.value = value;
+    }
+}
+type PromiseIteratorResult<T> = Promise<?Value<T>>
+
+type PromiseIterator<T> = {
+    next(): PromiseIteratorResult<T>;
+}

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -2,6 +2,8 @@
  * Typed event emitters and data streams
  */
 
+import { PromiseIterable } from './promise-iterable';
+
 type Handler<T> = (value: T) => void;
 type Listener<T> = {
     handler: Handler<T>;
@@ -86,30 +88,31 @@ export class Stream<T> {
     finish: Emitter<void>;
     dispose: Disposer;
 
+
+    static fromPromiseIterable<T>(
+        iterable: PromiseIterable<T>
+    ): Stream<T> {
+        return new Stream((update, finish) => {
+            let disposed = false;
+            iterable.map(state => {
+                if (!disposed) {
+                    update(state);
+                }
+            }).resolveAllWhile(() => !disposed).then(() => {
+                if (!disposed) {
+                    finish();
+                }
+            });
+            return () => { disposed = true; };
+        });
+    }
+
     static generate<T>(
         initial: T,
         generate: (state: T) => Promise<T>,
         condition: (state: T) => boolean
     ): Stream<T> {
-        return new Stream((update, finish) => {
-            let disposed = false;
-            let iterate = (state) => {
-                generate(state).then((state) => {
-                    if (disposed) {
-                        // stop the iteration
-                        return;
-                    }
-                    update(state);
-                    if (condition(state)) {
-                        iterate(state);
-                    } else {
-                        finish(state);
-                    }
-                });
-            };
-            iterate(initial);
-            return () => { disposed = true; };
-        });
+        return Stream.fromPromiseIterable(PromiseIterable.fromGenerator(initial, generate, condition));
     }
 
     static combine<T>(streams: Array<Stream<T>>): Stream<Array<T>> {


### PR DESCRIPTION
Maybe the name is not ideal, but the idea is:

It's like Iterable, but the iterator.next() is a promise that resolves with the value.

It's basically a generalization of "array of promises that gets resolved after each other", but it's more clean and it has all the positive things that Iterator has (it's lazy, it can be infinite). All the operators are lazy. It handles rejections well (by rejecting resolveAll())

The only assumption is that next() will not happen while previous next() is happening, or things will break.

You can easily make PromiseIterable<T> from Promise<PromiseIterable<T>>, which is funny.
